### PR TITLE
Check if any registrations include the client_id

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -71,7 +71,7 @@ def oauth_callback():
         )
 
     registrations = user_resp.success_response["user"]["registrations"]
-    if registrations is None or len(registrations) == 0 or registrations[0]["applicationId"] != client_id:
+    if registrations is None or len(registrations) == 0 or not any(r["applicationId"] == client_id for r in requirements):
         print("User not registered for the application.")
         uri = "http://{}:5000/".format(host_ip)
         return render_template(


### PR DESCRIPTION
Based on the 5 minute tutorial, you are adding a second Application and authorizing the user to that Application. The existing python demo only checks if the first registration matches the client_id, and doesn't take in to account if other applications may be registered. To make this code work out of the box for the 5 minute tutorial, this change will check if any of the registrations match the client_id, as opposed to only the first registration returned.